### PR TITLE
Add symmetric gradient operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # CHANGES
 
 ## next version
-  - added tests for explicit imports and undocumented names
-  - JuliaFormatter
-  
+
+### Added
+
+  - tests for explicit imports and undocumented names
+  - Runic.jl code formatting
+  - new operators `symgrad_Voigt` and `εV` for symmetric gradients in Voigt notation
+
 ## v0.8 November 1, 2024
   - started changelog
   - first registered version since repository move (fixed some URL links in the doc and readme)

--- a/src/ExtendableFEM.jl
+++ b/src/ExtendableFEM.jl
@@ -33,7 +33,7 @@ using ExtendableFEMBase: ExtendableFEMBase, AbstractFiniteElement,
     integrate_segment!, lazy_interpolate!, nodevalues,
     nodevalues!, nodevalues_subset!, nodevalues_view,
     norms, unicode_gridplot, unicode_scalarplot,
-    update_basis!
+    update_basis!, SymmetricGradient
 using ExtendableGrids: ExtendableGrids, AT_NODES, AbstractElementGeometry,
     Adjacency, AssemblyType, BEdgeNodes, BFaceFaces,
     BFaceNodes, BFaceRegions, CellAssemblyGroups,
@@ -113,7 +113,7 @@ export print_table
 include("unknowns.jl")
 export Unknown
 export grid, dofgrid
-export id, grad, hessian, div, normalflux, tangentialflux, Δ, apply, curl1, curl2, curl3, laplace, tangentialgrad
+export id, grad, hessian, div, normalflux, tangentialflux, Δ, apply, curl1, curl2, curl3, laplace, tangentialgrad, symgrad_voigt, εV
 
 include("operators.jl")
 #export AbstractOperator

--- a/src/unknowns.jl
+++ b/src/unknowns.jl
@@ -179,6 +179,23 @@ alias for (u, TangentialGradient)
 """
 tangentialgrad(u) = (u, TangentialGradient)
 
+"""
+	symgrad_voigt(u, factor)
+
+alias for (u, SymmetricGradient{factor}) in Voigt notation.
+
+The `factor` is a real number applied to the (summed) off-diagonal entries.
+In the current implementation in ExtendableFEMBase, factor = 0.5 represents the Voigt strain mapping [σ₁₁ σ₂₂ σ₃₃ σ₁₃ σ₂₃ σ₁₂],
+while factor = 1.0 represents the Voigt strain mapping [ε₁₁ ε₂₂ ε₃₃ 2ε₁₃ 2ε₂₃ 2ε₁₂].
+"""
+symgrad_voigt(u, factor) = (u, SymmetricGradient{factor})
+
+"""
+	εV(u, factor)
+
+unicode alias for [`symgrad_voigt(u, factor)`](@ref).
+"""
+εV(u, factor) = symgrad_voigt(u, factor)
 
 """
 	grid(u)


### PR DESCRIPTION
This is my current idea how to add a high level symmetric gradient operator.

As we discussed, I want to highlight the Voigt notation for the user in the operator names.

Now, we have
 - `symgrad_voigt` and `εV` with `u` und `factor` as arguments.
 - no default for the parameter `factor`, since there is no canonical Voigt transformation (stress vs. strain: 1.0 vs. 0.5)

It plays well in my project, so I think it may be ready for merging.