### PR TITLE
Fix arg-dependent case of BilinearOperatorDG assemble!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,23 @@
 # CHANGES
 
-## next version
+## v1.0.1 April 16, 2025
 
-## v1.0.0 April 11, 2025
+### Fixed
+
+  - assemble! of (args-dependent) BilinearOperatorDG now works
+
+
+
+## v1.0.0 April 14, 2025
 
 ### Added
 
   - new example on coupled Stokes-Darcy (Example264)
 
-### Added
+### Changed
 
   - example `Example301` now also demonstrates a nonlinear problem solved by an iterative linear solver
     with preconditioning.
-
-### Changed
 
   - `solve` uses now the residual equation for the linear systems
   - facelift `Example250`.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExtendableFEM"
 uuid = "a722555e-65e0-4074-a036-ca7ce79a4aed"
 authors = ["Christian Merdon <merdon@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/common_operators/bilinear_operator_dg.jl
+++ b/src/common_operators/bilinear_operator_dg.jl
@@ -1070,7 +1070,7 @@ function assemble!(A::FEMatrix, O::BilinearOperatorDG{Tv, UT}, sol = nothing; as
     ind_args = O.u_args
     return if length(O.u_args) > 0
         build_assembler!(A.entries, O, [A[j, j] for j in ind_test], [A[j, j] for j in ind_ansatz], [sol[j] for j in ind_args]; kwargs...)
-        O.assembler(A.entries, [sol[j] for j in ind_args])
+        O.assembler(A.entries, nothing, [sol[j] for j in ind_args])
     else
         build_assembler!(A.entries, O, [A[j, j] for j in ind_test], [A[j, j] for j in ind_ansatz]; kwargs...)
         O.assembler(A.entries, nothing)


### PR DESCRIPTION
fixes a case where a wrong number of arguments were passed to the assembler