### PR TITLE
fixed FixedDofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGES
 
+## v1.1.1 April 29, 2025
+
+### Fixed
+  - FixDofs operator does not crash when system matrix is of type GenericMTExtendableSparseMatrixCSC
+  
 ## v1.1.0 April 17, 2025
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExtendableFEM"
 uuid = "a722555e-65e0-4074-a036-ca7ce79a4aed"
 authors = ["Christian Merdon <merdon@wias-berlin.de>", "Patrick Jaap <patrick.jaap@wias-berlin.de>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 CommonSolve = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"

--- a/src/common_operators/fixdofs_operator.jl
+++ b/src/common_operators/fixdofs_operator.jl
@@ -50,6 +50,8 @@ function FixDofs(u; dofs = [], vals = zeros(Float64, length(dofs)), kwargs...)
     return FixDofs{typeof(u), typeof(dofs), typeof(vals)}(u, dofs, 0, vals, nothing, parameters)
 end
 
+_myset(a, b) = b
+
 function apply_penalties!(A, b, sol, O::FixDofs{UT}, SC::SolverConfiguration; assemble_matrix = true, assemble_rhs = true, kwargs...) where {UT}
     if UT <: Integer
         ind = O.u
@@ -64,7 +66,7 @@ function apply_penalties!(A, b, sol, O::FixDofs{UT}, SC::SolverConfiguration; as
         AE = A.entries
         for j in 1:length(dofs)
             dof = dofs[j] + offset
-            AE[dof, dof] = penalty
+            rawupdateindex!(AE, _myset, penalty, dof, dof, 1)
         end
     end
     if assemble_rhs

--- a/src/common_operators/fixdofs_operator.jl
+++ b/src/common_operators/fixdofs_operator.jl
@@ -50,8 +50,6 @@ function FixDofs(u; dofs = [], vals = zeros(Float64, length(dofs)), kwargs...)
     return FixDofs{typeof(u), typeof(dofs), typeof(vals)}(u, dofs, 0, vals, nothing, parameters)
 end
 
-_myset(a, b) = b
-
 function apply_penalties!(A, b, sol, O::FixDofs{UT}, SC::SolverConfiguration; assemble_matrix = true, assemble_rhs = true, kwargs...) where {UT}
     if UT <: Integer
         ind = O.u
@@ -66,7 +64,7 @@ function apply_penalties!(A, b, sol, O::FixDofs{UT}, SC::SolverConfiguration; as
         AE = A.entries
         for j in 1:length(dofs)
             dof = dofs[j] + offset
-            rawupdateindex!(AE, _myset, penalty, dof, dof, 1)
+            rawupdateindex!(AE, (a, b) -> b, penalty, dof, dof, 1)
         end
     end
     if assemble_rhs


### PR DESCRIPTION
FixedDofs assembly crashed when other operators of the problem are assembled in parallel and cause the system matrix to be of type GenericMTExtendableSparseMatrixCSC. This is fixed by avoiding the setindex! function and instead using rawupdateindex!