### PR TITLE
Fixed GenericMTExtendableSparseMatrixCSC assembly in HomogeneousData and InterpolateBoundaryData operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # CHANGES
 
-## v1.1.2 May 23, 2025
-
-### Fixed
-  - HomogeneousData and InterpolateBoundaryData operators do not crash when system matrix is of type GenericMTExtendableSparseMatrixCSC
-  
 ## v1.1.1 April 29, 2025
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGES
 
+## v1.1.2 May 23, 2025
+
+### Fixed
+  - HomogeneousData and InterpolateBoundaryData operators do not crash when system matrix is of type GenericMTExtendableSparseMatrixCSC
+  
 ## v1.1.1 April 29, 2025
 
 ### Fixed

--- a/src/common_operators/homogeneousdata_operator.jl
+++ b/src/common_operators/homogeneousdata_operator.jl
@@ -174,7 +174,7 @@ function apply_penalties!(A, b, sol, O::HomogeneousData{UT}, SC::SolverConfigura
             penalty = O.parameters[:penalty]
             AE = A.entries
             for dof in bdofs
-                AE[dof, dof] = penalty
+                rawupdateindex!(AE, (a, b) -> b, penalty, dof, dof, 1)
             end
             flush!(AE)
         end

--- a/src/common_operators/interpolateboundarydata_operator.jl
+++ b/src/common_operators/interpolateboundarydata_operator.jl
@@ -204,7 +204,7 @@ function apply_penalties!(A, b, sol, O::InterpolateBoundaryData{UT}, SC::SolverC
         if assemble_matrix
             AE = A.entries
             for dof in bdofs
-                AE[dof, dof] = penalty
+                rawupdateindex!(AE, (a, b) -> b, penalty, dof, dof, 1)
             end
             flush!(AE)
         end


### PR DESCRIPTION
Similar bugfix as in version 1.1.1 for FixedDofs also required for the other operators mentioned in the title