### PR TITLE
Start implementing parallel periodic coupling

### DIFF
--- a/src/helper_functions.jl
+++ b/src/helper_functions.jl
@@ -209,6 +209,15 @@ function get_periodic_coupling_matrix(
     return _get_periodic_coupling_matrix(FES, xgrid, b_from, b_to, give_opposite!; kwargs...)
 end
 
+# merge matrix B into A, overriding the entries of A if an entry is both present in A and B
+function merge!(A::ExtendableSparseMatrix, B::ExtendableSparseMatrix)
+    rows, cols, values = findnz(B)
+    for (row, col, value) in zip(rows, cols, values)
+        A[row, col] = value
+    end
+    return nothing
+end
+
 function _get_periodic_coupling_matrix(
         FES::FESpace{Tv},
         xgrid::ExtendableGrid{TvG, TiG},
@@ -216,7 +225,9 @@ function _get_periodic_coupling_matrix(
         b_to,
         give_opposite!::Function;
         mask = :auto,
-        sparsity_tol = 1.0e-12
+        sparsity_tol = 1.0e-12,
+        parallel = true,
+        threads = Threads.nthreads()
     ) where {Tv, TvG, TiG}
 
     @info "Computing periodic coupling matrix. This may take a while."
@@ -238,18 +249,6 @@ function _get_periodic_coupling_matrix(
 
     # FE basis dofs on each boundary face
     dofs_on_boundary = FES[BFaceDofs]
-
-    # fe vector used for interpolation
-    fe_vector = FEVector(FES)
-    # to be sure
-    fill!(fe_vector.entries, 0.0)
-
-    # FE vector for interpolation
-    fe_vector_target = FEVector(FES)
-
-    # resulting sparse matrix
-    n = length(fe_vector.entries)
-    result = ExtendableSparseMatrix(n, n)
 
     # face numbers of the boundary faces
     face_numbers_of_bfaces = xgrid[BFaceFaces]
@@ -306,8 +305,6 @@ function _get_periodic_coupling_matrix(
         return
     end
 
-    eval_point, set_start = interpolate_on_boundaryfaces(fe_vector, xgrid, give_opposite!)
-
     # precompute approximate search region for each boundary face in b_from
     searchareas = ExtendableGrids.VariableTargetAdjacency(TiG)
     coords = xgrid[Coordinates]
@@ -358,13 +355,42 @@ function _get_periodic_coupling_matrix(
         append!(searchareas, view(faces_to, 1:nfaces_to))
     end
 
-    # loop over boundary face indices: we need this index for dofs_on_boundary
-    for i_boundary_face in 1:n_boundary_faces
+    # we are only interest in global bface numbers on the "from" boundary
+    bfaces_of_interest = filter(face -> boundary_regions[face] in b_from, 1:n_boundary_faces)
+    n_bface_of_interest = length(bfaces_of_interest)
 
-        # for each boundary face: check if in b_from
-        if boundary_regions[i_boundary_face] in b_from
+    # we loop ober the n_boundary_faces in parallel:
+    # create chunks to split this range for the threads
+    if parallel
+        chuck_length = Int(ceil(n_bface_of_interest / threads))
+    else
+        chuck_length = n_bface_of_interest
+    end
+    chunks = Iterators.partition(bfaces_of_interest, chuck_length)
 
-            local_dofs = @views dofs_on_boundary[:, i_boundary_face]
+    # loop over boundary face indices in a chunk: we need this index for dofs_on_boundary
+    function compute_chunk_result(chunk)
+
+        @info "start $chunk"
+
+        # prepare data for this chunk
+
+        # we need our own copy of the FE Space to avoid data race in the pre-computed interpolators
+        our_FES = deepcopy(FES)
+        local fe_vector = FEVector(our_FES)
+        # to be sure
+        fill!(fe_vector.entries, 0.0)
+
+        local fe_vector_target = FEVector(our_FES)
+
+        local n = length(fe_vector.entries)
+        local result = ExtendableSparseMatrix(n, n)
+
+        local eval_point, _ = interpolate_on_boundaryfaces(fe_vector, xgrid, give_opposite!)
+
+        for i_boundary_face in chunk
+
+            local local_dofs = @views dofs_on_boundary[:, i_boundary_face]
             for local_dof in local_dofs
                 # compute number of component
                 if mask[1 + ((local_dof - 1) ÷ coffset)] == 0.0
@@ -379,7 +405,7 @@ function _get_periodic_coupling_matrix(
 
                 # interpolate on the opposite boundary using x_trafo = give_opposite
 
-                j = findfirst(==(face_numbers_of_bfaces[i_boundary_face]), faces_in_b_from)
+                local j = findfirst(==(face_numbers_of_bfaces[i_boundary_face]), faces_in_b_from)
                 if j <= 0
                     throw("face $(face_numbers_of_bfaces[i_boundary_face]) is not on source boundary. Are the from/to regions and the give_opposite function correct?")
                 end
@@ -401,6 +427,28 @@ function _get_periodic_coupling_matrix(
                 end
             end
         end
+        @info "finish $chunk"
+
+        return result
+    end
+
+    @info "start $(length(chunks)) tasks..."
+
+    # show start all chunks in parallel
+    tasks = map(chunks) do chunk
+        Threads.@spawn compute_chunk_result(chunk)
+    end
+
+    @info "done..."
+    # wait for all chunks to finish and get results
+    results = fetch.(tasks)
+
+    @info "fetched results ..."
+
+    # merge all matrices
+    result = results[begin]
+    for res_i in results[(begin + 1):end]
+        merge!(result, res_i)
     end
 
     sp_result = sparse(result)


### PR DESCRIPTION
This is WIP.

The range of boundary_faces is split into chunks and each chunk computes a separate result.

In the end, each result is "merged" into the final result, since we compute several entries multiple times. Hence, no simple `+` reduction...

Works great on my machine with 12 threads:
```
using ExtendableFEM, ExtendableGrids
FES = FESpace{H1P1{3}}( uniform_refine( grid_unitcube( Tetrahedron3D ) , 3) )
g(x,y) = begin x .= y; x[1] = 1 - y[1] end

@time matrix = get_periodic_coupling_matrix(FES, 2, 4, g,  threads = XXX) #
```

| threads | time |
|-------------|---------|
| 1 | 4,9 |
| 2 | 2.5 |
| 3 | 1.5 |
|4 | 1.25|
|5| 1.1 |
|6 | 1.0 |

then is stays at around 1s. 


Some TODOs/discussion points
- [ ] we need to enforce private FES for the chunks, otherwise the interpolators cause data races
- [ ] no method to merge two matrices, this is done by hand right now
- [ ] all local variables in the loop need to be `local` (I did not fully understand why)
